### PR TITLE
Removed deprecated domain (now pinpayments.com)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,9 +15,6 @@ build/
 [Bb]in/
 [Oo]bj/
 
-# Enable "build/" folder in the NuGet Packages folder since NuGet packages use it for MSBuild targets
-!packages/*/build/
-
 # MSTest test Results
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*

--- a/PinPayments.Console/Program.cs
+++ b/PinPayments.Console/Program.cs
@@ -14,10 +14,10 @@ namespace PinPayments.Console
         static void Main(string[] args)
         {
             // initialise PIN by passing your API Key
-            // See:  https://pin.net.au/docs/api#keys
+            // See:  https://pinpayments.com/docs/api#keys
             PinService ps = new PinService(ConfigurationManager.AppSettings["Secret_API"]);
 
-            // https://pin.net.au/docs/api/test-cards
+            // https://pinpayments.com/docs/api/test-cards
             // 5520000000000000 - Test Mastercard
             // 4200000000000000 - Test Visa
 
@@ -39,7 +39,7 @@ namespace PinPayments.Console
 
 
             // Refunds - Pin supports partial refunds
-            // https://pin.net.au/docs/api/customers#get-customers-charges
+            // https://pinpayments.com/docs/api/customers#get-customers-charges
 
             var refund = ps.Refund(response.Token, 200);
             refund = ps.Refund(response.Token, 100);
@@ -47,7 +47,7 @@ namespace PinPayments.Console
             var refunds = ps.Refunds(response.Token);
 
             // Searching for a Charge
-            // See https://pin.net.au/docs/api/charges#search-charges for more detail
+            // See https://pinpayments.com/docs/api/charges#search-charges for more detail
 
             var respChargesSearch = ps.ChargesSearch(new Actions.ChargeSearch { Query = "", Sort = ChargeSearchSortEnum.Amount, SortDirection = SortDirectionEnum.Descending });
             System.Console.WriteLine(respChargesSearch.Count.ToString() + " transactions found");
@@ -61,10 +61,10 @@ namespace PinPayments.Console
 
 
             // Create Customer
-            // See: https://pin.net.au/docs/api/customers#post-customers
+            // See: https://pinpayments.com/docs/api/customers#post-customers
 
             var customer = new Customer();
-            customer.Email = "roland@pin.net.au";
+            customer.Email = "roland@pinpayments.com";
             customer.Card = new Card();
             customer.Card.CardNumber = "5520000000000000";
             customer.Card.ExpiryMonth = "05";
@@ -115,7 +115,7 @@ namespace PinPayments.Console
             var respCustomerCharge = ps.Charge(new PostCharge { IPAddress = "127.0.0.1", Amount = 1000, Description = "Charge by customer token: " + customer.Email, Email = customer.Email, CustomerToken = customer.Token });
 
             // Card Token
-            // https://pin.net.au/docs/api/cards
+            // https://pinpayments.com/docs/api/cards
             // 5520000000000000 - Test Mastercard
             // 4200000000000000 - Test Visa
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 PinPayments Library
 ==========
 
-The PinPayments Library is a .net wrapper for http://pin.net.au. 
+The PinPayments Library is a .net wrapper for http://pinpayments.com. 
 
-For more information about the examples below, you can visit https://pin.net.au/docs/api for a full reference.
+For more information about the examples below, you can visit https://pinpayments.com/docs/api for a full reference.
 
 (Inspiration and thanks to Jayme Davis's Stripe implemetnation:  https://github.com/jaymedavis/stripe.net)
 
 Quick Start
 -----------
 
-a) Obtain either your Publish key or your Secret key (see the differences here: https://pin.net.au/docs/api)
+a) Obtain either your Publish key or your Secret key (see the differences here: https://pinpayments.com/docs/api)
 
 b) Update your AppSetting with your api key to your config (this is the easiest way)
 
@@ -40,7 +40,7 @@ Charges
 
 	PinService ps = new PinService(ConfigurationManager.AppSettings["Secret_API"]);
 
-	// https://pin.net.au/docs/api/test-cards
+	// https://pinpayments.com/docs/api/test-cards
 	// 5520000000000000 - Mastercard
 	// 4200000000000000 - Visa
 
@@ -63,7 +63,7 @@ Charges
 	
 ### Charge Search
 
-	// See https://pin.net.au/docs/api/charges#search-charges for more detail
+	// See https://pinpayments.com/docs/api/charges#search-charges for more detail
     PinService ps = new PinService(ConfigurationManager.AppSettings["Secret_API"]);
 
     var cs = new PinPayments.ChargeSearch { Query = "", Sort = ChargeSearchSortEnum.Amount, SortDirection = SortDirectionEnum.Descending };
@@ -79,18 +79,18 @@ Customers
 -----
 
 ### Listing all customers
-    // See https://pin.net.au/docs/api/customers#get-customers
+    // See https://pinpayments.com/docs/api/customers#get-customers
     ps = new PinService(ConfigurationManager.AppSettings["Secret_API"]);
     var customers = ps.Customers();
 	
 	
 ### Adding a new customer
 	
-    // See https://pin.net.au/docs/api/customers#post-customers for more detail
+    // See https://pinpayments.com/docs/api/customers#post-customers for more detail
     ps = new PinService(ConfigurationManager.AppSettings["Secret_API"]);
 
     var customer = new Customer();
-    customer.Email = "roland@pin.net.au";
+    customer.Email = "roland@pinpayments.com";
     customer.Card = new Card();
     customer.Card.CardNumber = "5520000000000000";
     customer.Card.ExpiryMonth = "05";
@@ -111,7 +111,7 @@ Customers
 	
 ### Updating a customer
 
-    // See https://pin.net.au/docs/api/customers#put-customer
+    // See https://pinpayments.com/docs/api/customers#put-customer
     ps = new PinService(ConfigurationManager.AppSettings["Secret_API"]);
     var customers = ps.Customers();
     customer = customers.Customer[0];
@@ -135,7 +135,7 @@ Customers
 ### Refunds
 
     // Refunds - Pin supports partial refunds
-    // https://pin.net.au/docs/api/customers#get-customers-charges
+    // https://pinpayments.com/docs/api/customers#get-customers-charges
 
     var refund = ps.Refund("INSERT CHARGE TOKEN", 200);
     refund = ps.Refund("INSERT CHARGE TOKEN", 100);
@@ -148,7 +148,7 @@ Customers
 ### Card Tokens
 
     // Card Token
-    // https://pin.net.au/docs/api/cards
+    // https://pinpayments.com/docs/api/cards
     // 5520000000000000 - Test Mastercard
     // 4200000000000000 - Test Visa
 


### PR DESCRIPTION
While pin.net.au continues to work, it has been deprecated. This PR updates the URLs to point to the international domain that Pin Payments is shifting to the fore.